### PR TITLE
Refactor the patch detection logic to use the Update Build Revision (…

### DIFF
--- a/Scripts/Detection.ps1
+++ b/Scripts/Detection.ps1
@@ -1,28 +1,49 @@
 # This script is used by Intune to detect if the application is already installed.
-# It checks if the correct KB for the device's OS build is present.
+# It checks if the device's OS Update Build Revision (UBR) is at or above the required minimum.
 
 $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
-$kbMap = Import-Csv -Path (Join-Path $PSScriptRoot "kbmap.csv") -ErrorAction SilentlyContinue
+$kbMapPath = Join-Path $PSScriptRoot "kbmap.csv"
 
-# If the CSV map doesn't exist, something is wrong with the package content.
+# Check if the map file exists.
+if (-not (Test-Path $kbMapPath)) {
+    Write-Host "Detection script failed: kbmap.csv not found at '$kbMapPath'."
+    exit 1
+}
+$kbMap = Import-Csv -Path $kbMapPath -ErrorAction SilentlyContinue
+
+# If the CSV map is empty or unreadable, something is wrong with the package content.
 if ($null -eq $kbMap) {
+    Write-Host "Detection script failed: Could not import or parse kbmap.csv."
     exit 1
 }
 
+# Get OS Build and UBR (Update Build Revision)
 $osInfo = Get-CimInstance Win32_OperatingSystem
-$build = [int]$osInfo.BuildNumber
+$currentBuild = $osInfo.BuildNumber
+try {
+    $currentUBR = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name "UBR" -ErrorAction Stop).UBR
+} catch {
+    # This key might not exist on a freshly installed OS before the first CU.
+    $currentUBR = 0
+}
+
 
 # Find the entry in the map for this specific OS build.
-$kbEntry = $kbMap | Where-Object { $_.Build -eq $build.ToString() }
+$kbEntry = $kbMap | Where-Object { $_.Build -eq $currentBuild }
 
 if ($kbEntry) {
-    $kbNumber = $kbEntry.KB
-    # Check if the hotfix is installed. If so, exit with 0 to indicate "Found".
-    if (Get-HotFix -Id $kbNumber -ErrorAction SilentlyContinue) {
-        Write-Host "Detection successful: KB$($kbNumber) is installed."
+    $requiredUBR = [int]$kbEntry.UBR
+
+    # Check if the current UBR is greater than or equal to the required UBR.
+    if ($currentUBR -ge $requiredUBR) {
+        Write-Host "Detection successful: Current UBR ($currentUBR) meets or exceeds required UBR ($requiredUBR)."
         exit 0
+    } else {
+        Write-Host "Detection failed: Current UBR ($currentUBR) is less than required UBR ($requiredUBR)."
+        exit 1
     }
 }
 
-# If we get here, the KB is not installed or not applicable. Exit with 1 to indicate "Not Found".
+# If we get here, the OS build was not found in the map.
+Write-Host "Detection failed: OS Build $currentBuild not found in kbmap.csv."
 exit 1


### PR DESCRIPTION
…UBR) number instead of the specific KB number.

The previous method of checking for a specific KB number was unreliable. If a device had a pre-Patch-Tuesday "preview" update, it would have the necessary fixes but a different KB number, causing the detection to fail.

This change modifies the scripts to:
- `Generate-KBMap.ps1`: Now scrapes the Microsoft support page for the relevant cumulative update to find the associated UBR number (e.g., 22631.xxxx). It stores this UBR in the `kbmap.csv`.
- `Detection.ps1`: Now reads the required UBR from `kbmap.csv` and compares it against the local machine's UBR, which is read from the registry.

This ensures that any device with a UBR greater than or equal to the official Patch Tuesday release is correctly identified as compliant, making the detection far more robust.