### PR TITLE
diag: Replace detection script with a diagnostic version

### DIFF
--- a/Scripts/Detection.ps1
+++ b/Scripts/Detection.ps1
@@ -1,77 +1,35 @@
-# This script is used by Intune to detect if the application is already installed.
-# It checks if the device's OS Update Build Revision (UBR) is at or above the required minimum.
+# --- DIAGNOSTIC SCRIPT ---
+# This script is designed to help debug the execution context of Intune detection scripts.
+# It logs environment information and then exits with an error code to ensure the output is captured.
 
-# In the Intune detection script context, the working directory is the root of the extracted package.
-# We can therefore reference kbmap.csv directly. Using $MyInvocation is unreliable here.
-$kbMapPath = "kbmap.csv"
-
-# Check if the map file exists.
-if (-not (Test-Path $kbMapPath)) {
-    Write-Host "Detection script failed: kbmap.csv not found at '$kbMapPath'."
-    exit 1
-}
-$kbMap = Import-Csv -Path $kbMapPath -ErrorAction SilentlyContinue
-
-# If the CSV map is empty or unreadable, something is wrong with the package content.
-if ($null -eq $kbMap) {
-    Write-Host "Detection script failed: Could not import or parse kbmap.csv."
-    exit 1
-}
-
-# Get OS and architecture information
 try {
-    $osInfo = Get-CimInstance Win32_OperatingSystem
-    $currentBuild = $osInfo.BuildNumber
-    $currentUBR = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name "UBR" -ErrorAction Stop).UBR
+    Write-Host "--- Starting Diagnostic Logging ---"
 
-    # Determine system architecture to find the correct entry in the map.
-    $arch = $env:PROCESSOR_ARCHITECTURE
-    if ($arch -eq 'AMD64') {
-        $mappedArch = 'x64'
-    } elseif ($arch -eq 'ARM64') {
-        $mappedArch = 'arm64'
-    } else {
-        Write-Host "Detection failed: Unsupported processor architecture '$arch'."
-        exit 1
+    # 1. Log Current Working Directory
+    $cwd = Get-Location
+    Write-Host "Current Working Directory: $($cwd.Path)"
+
+    # 2. Log content of automatic variables
+    Write-Host "PSScriptRoot automatic variable: $PSScriptRoot"
+    Write-Host "MyInvocation.MyCommand.Path: $($MyInvocation.MyCommand.Path)"
+    Write-Host "MyInvocation.MyCommand.Definition: $($MyInvocation.MyCommand.Definition)"
+
+    # 3. Log recursive file listing from the current directory
+    Write-Host "--- Recursive File Listing from CWD ---"
+    Get-ChildItem -Path $cwd.Path -Recurse | ForEach-Object { Write-Host $_.FullName }
+    Write-Host "--- End File Listing ---"
+
+    # 4. Attempt to find the kbmap.csv from a few common relative paths
+    $pathsToTest = @("kbmap.csv", ".\kbmap.csv", "..\kbmap.csv", "Scripts\kbmap.csv", ".\Scripts\kbmap.csv")
+    foreach ($path in $pathsToTest) {
+        $found = Test-Path $path -PathType Leaf
+        Write-Host "Testing path '$path'... Found: $found"
     }
 }
 catch {
-    # This key might not exist on a freshly installed OS before the first CU.
-    if ($_.Exception.Message -like "*Cannot find path*HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion*because it does not exist*") {
-        $currentUBR = 0
-    } else {
-        Write-Host "Detection failed: Could not retrieve OS or architecture information. Error: $_"
-        exit 1
-    }
+    Write-Error "An error occurred during diagnostic script execution: $_"
 }
-
-# Find the entry in the map for this specific OS build and architecture.
-$kbEntry = $kbMap | Where-Object { $_.Build -eq $currentBuild -and $_.Arch -eq $mappedArch }
-
-if ($kbEntry) {
-    # Ensure there is only one entry found. If multiple, it's an error.
-    if ($kbEntry.Count -gt 1) {
-        Write-Host "Detection failed: Found multiple matching entries for build $currentBuild and architecture $mappedArch."
-        exit 1
-    }
-
-    try {
-        $requiredUBR = [int]$kbEntry.UBR
-        # Check if the current UBR is greater than or equal to the required UBR.
-        if ($currentUBR -ge $requiredUBR) {
-            Write-Host "Detection successful: Current UBR ($currentUBR) meets or exceeds required UBR ($requiredUBR)."
-            exit 0
-        } else {
-            Write-Host "Detection failed: Current UBR ($currentUBR) is less than required UBR ($requiredUBR)."
-            exit 1
-        }
-    }
-    catch {
-        Write-Host "Detection script failed during UBR comparison. Error: $_"
-        exit 1
-    }
+finally {
+    Write-Error "--- Diagnostic Run Complete. Exiting with error code 1 to ensure logs are visible. ---"
+    exit 1
 }
-
-# If we get here, the OS build was not found in the map.
-Write-Host "Detection failed: OS Build $currentBuild not found in kbmap.csv."
-exit 1


### PR DESCRIPTION
This commit temporarily replaces the `Detection.ps1` script with a diagnostic script. This is intended to be deployed via Intune to a test client to debug a "file not found" error.

The diagnostic script does the following:
- Logs the current working directory.
- Logs the values of several automatic PowerShell variables (`$PSScriptRoot`, `$MyInvocation`).
- Performs a recursive listing of all files and folders from the current directory.
- Explicitly tests several common relative paths for `kbmap.csv`.
- Exits with code 1 to ensure the detection state is "Not Detected" and the log output is generated.

This is a temporary measure to gather information about the script's execution context within Intune. This branch should not be merged. The findings will be used to create a permanent fix.